### PR TITLE
Feature to Implement Book Retrieval by ID

### DIFF
--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -48,6 +48,16 @@ async def create_book(book: Book):
 async def get_books() -> OrderedDict[int, Book]:
     return db.get_books()
 
+@router.get("/{book_id}", response_model = Book, status_code = status.HTTP_200_OK)
+async def get_book_by_id(book_id: int) -> Book:
+    book = db.get_book_by_id(book_id)
+    if not book:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Book with id {book_id} not found",
+        )
+    return book
+
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
 async def update_book(book_id: int, book: Book) -> Book:

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -50,7 +50,7 @@ async def get_books() -> OrderedDict[int, Book]:
 
 @router.get("/{book_id}", response_model = Book, status_code = status.HTTP_200_OK)
 async def get_book_by_id(book_id: int) -> Book:
-    book = db.get_book_by_id(book_id)
+    book = db.get_book(book_id)
     if not book:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -56,7 +56,7 @@ async def get_book_by_id(book_id: int) -> Book:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Book with id {book_id} not found",
         )
-    return book
+    return JSONResponse(status_code=status.HTTP_200_OK, content=book.model_dump())
 
 
 @router.put("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
What does this PR do?

Implements the /api/v1/books/{book_id} endpoint that retrieves a book by its ID.
Handles 404 errors when the book is not found in the database.
Why is this change necessary?

This change adds the ability to retrieve individual books by their book_id, which is a critical feature for our book management API.
How do you test this PR?

Run the FastAPI application and visit /api/v1/books/{book_id} to retrieve book details.
Test with both existing book IDs (to check for valid responses) and invalid IDs (to ensure proper 404 responses).
Any important information to note?

No modifications to main.py were made. The new functionality was added to a new endpoint as per project guidelines.
The PR is ready for review and testing.